### PR TITLE
Since 3.3, a new warning message is added to WordPress. wp_enqueue_scrip...

### DIFF
--- a/gravityforms-placeholders.php
+++ b/gravityforms-placeholders.php
@@ -12,7 +12,10 @@ Just add a "gplaceholder" CSS classname to the required fields.
 
 */
 
-if (is_admin() || (isset($GLOBALS['pagenow']) && $GLOBALS['pagenow'] == 'wp-login.php'))
+if ( isset( $GLOBALS['pagenow'] ) && $GLOBALS['pagenow'] == 'wp-login.php' )
 	return;
 
-wp_enqueue_script("_gf_placeholders", plugins_url(null, __FILE__) . "/gf.placeholders.js.php", array("jquery"), "1.0");
+add_action( 'wp_print_scripts', 'gf_placeholder_enqueue_scripts' );
+function gf_placeholder_enqueue_scripts() {
+	wp_enqueue_script( '_gf_placeholders', plugins_url( null, __FILE__ ) . '/gf.placeholders.js.php', array( 'jquery'), '1.0' );
+}


### PR DESCRIPTION
...t needs to be called within a hook.

This also eliminates the need for the is_admin check because this hook only runs on front end pages.

See http://codex.wordpress.org/Function_Reference/wp_enqueue_script for more info.
