### PR TITLE
Update gf.placeholders.js

### DIFF
--- a/gf.placeholders.js
+++ b/gf.placeholders.js
@@ -2,7 +2,7 @@
 
 var gf_placeholder = function() {
 
-	$('.gform_wrapper .gplaceholder')
+	$('.gform_wrapper')
 		.find('input, textarea').filter(function(i){
 			var $field = $(this);
 			


### PR DESCRIPTION
Removed .gplaceholder from jQuery selection. I couldn't find this HTML class in my Gravity forms output.
