### PR TITLE
Show .gfield_label

### DIFF
--- a/gf.placeholders.js
+++ b/gf.placeholders.js
@@ -40,6 +40,7 @@ var gf_placeholder = function() {
 			},
 			type: 'get'
 		});
+	$('.gfield_label').show();
 };
 
 $(document).ready(function(){


### PR DESCRIPTION
Gravity Forms has 2 levels of label .gfield_label and input level labels. Seeing as it's only the input the level labels that are using as placeholders by this plugin, I figured I would re-show the .gfield_label labels.
