### PR TITLE
Update gf.placeholders.js

### DIFF
--- a/gf.placeholders.js
+++ b/gf.placeholders.js
@@ -17,6 +17,10 @@ var gf_placeholder = function() {
 			var $field = $(this);
 
 			var id = this.id;
+			if (id === '') {
+				return;
+			}
+			
 			var $labels = $('label[for=' + id + ']').hide();
 			var label = $labels.last().text();
 


### PR DESCRIPTION
Some inputs have no Id and it throws 'unrecognized expression: label[for=]'
